### PR TITLE
Extract timestamp from log line

### DIFF
--- a/loggy.cabal
+++ b/loggy.cabal
@@ -12,6 +12,7 @@ extra-source-files:  README.md
 
 common common-options
   build-depends: base >=4.14 && <4.15,
+                 time
   ghc-options:   -Wall
                  -Wcompat
                  -Widentities

--- a/src/LoggyCore.hs
+++ b/src/LoggyCore.hs
@@ -1,1 +1,13 @@
 module LoggyCore where
+
+import Data.Time
+
+type DateFormat = String
+
+extract_timestamp :: DateFormat -> String -> Maybe UTCTime
+extract_timestamp dformat line = parsed_ts
+    where
+        parsed_ts = case time_parser line of
+            [(ts, _)] -> Just ts
+            _ -> Nothing
+        time_parser = readSTime True defaultTimeLocale dformat


### PR DESCRIPTION
This patch sets up the function which can parse a given log line
containing the user supplied timestamp strftime type along with a log
line. The resulting output can also be compared as it inherits the Ord
kind.
Pending additional unit and property based testing of the output.