### PR TITLE
Handle invalid log lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,15 @@ Available options:
     - [x] With same format
     - [x] With different formats
   - [x] Add unit tests(HUnit)
-  - [ ] Remove "error" on parse issues, replace with "Maybe"
-  - [ ] Look into doctest to clean up unit tests
+  - [x] Remove "error" on parse issues, replace with "Maybe"
   - [ ] Add -Weverything flag
+  - [ ] `fileembed` with actual data + setup of regression tests
   - [ ] Add Github CI (optional)
 - [ ] Checkpoint 3: Performance
   - [ ] Use Vector/Text
   - [ ] Use heap for low memory consumption/Use streaming library
   - [ ] Benchmarks(optional)
 - [ ] Checkpoint 4: Stretch goals
-  - [ ] `fileembed` with actual data + setup of regression tests
   - [ ] Adding quickcheck testing(how to model strftime/log file inputs)
   - [ ] Pull in remote files
   - [ ] Terminal coloring
@@ -54,3 +53,4 @@ Available options:
   - [ ] Print output in a range of timestamps
   - [ ] Group lines without timestamps
   - [ ] Reading log files in parallel
+  - [ ] Look into doctest to clean up unit tests

--- a/executables/LoggyMain.hs
+++ b/executables/LoggyMain.hs
@@ -1,7 +1,10 @@
 module Main where
 
 import Options.Applicative
-import LoggyCore (mergeLogLines, DateFormat)
+import LoggyCore (mergeLogLines, DateFormat, MergeResult(MkMergeResult), WarnCode(InvalidLogLine))
+import Control.Monad (when)
+import System.IO (hPutStrLn, stderr)
+
 
 type FileName = String
 type InputArg = String
@@ -48,7 +51,8 @@ runMain :: [LoggyArg] -> IO ()
 runMain loggyArgs = do
   linesPerFile <- (fmap.fmap) lines (mapM readFile fileNames)
   let dFmtFileLinesPairs = zip dateFormats linesPerFile
-  let mergedLines = mergeLogLines dFmtFileLinesPairs
+  let MkMergeResult mergedLines warnCode = mergeLogLines dFmtFileLinesPairs
+  when (warnCode == InvalidLogLine) $ hPutStrLn stderr "[warn] Invalid log line(s) in input, ignoring."
   putStrLn $ unlines mergedLines
     where
       fileNames = argFilename <$> loggyArgs

--- a/src/LoggyCore.hs
+++ b/src/LoggyCore.hs
@@ -1,25 +1,38 @@
 module LoggyCore where
 
 import Data.Time
+import Data.Maybe
 import GHC.Exts (sortWith)
 
 type LogLine = String
 type LogFileLines = [LogLine]
 type DateFormat = String
+data WarnCode = NoWarning | InvalidLogLine deriving (Eq, Show)
+data MergeResult = MkMergeResult
+    {
+        mergeResultOutput   :: LogFileLines,
+        mergeResultWarning  :: WarnCode
+    }  deriving (Eq, Show)
 
-extractTimestamp :: DateFormat -> LogLine -> UTCTime
+extractTimestamp :: DateFormat -> LogLine -> Maybe UTCTime
 extractTimestamp dformat line = parsedTs
     where
         parsedTs = case timeParser line of
-            [(ts, _)] -> ts
-            _ -> error "Invalid log line!"
+            [(ts, _)] -> Just ts
+            _ -> Nothing
         timeParser = readSTime True defaultTimeLocale dformat
 
-mergeLogLines :: [(DateFormat, LogFileLines)] -> [LogLine]
-mergeLogLines dfmtFilePairs = sortedLogLines
+mergeLogLines :: [(DateFormat, LogFileLines)] -> MergeResult
+mergeLogLines dfmtFilePairs = MkMergeResult sortedLogLines warnCode
     where
+        warnCode :: WarnCode
+        warnCode
+            | length sortedLogLines /= length tsLineTuples = InvalidLogLine
+            | otherwise                                    = NoWarning
         sortedLogLines = snd <$> sortedLogTuples
-        sortedLogTuples = sortWith fst $ zip logTimestamps logLines
+        sortedLogTuples = sortWith fst tsLineTuplesFiltered
+        tsLineTuplesFiltered = filter (isJust.fst) tsLineTuples
+        tsLineTuples = zip logTimestamps logLines
         logTimestamps = concat $ zipWith ($) (fmap.extractTimestamp <$> dformats) linesPerLf
         logLines = concat linesPerLf
         dformats = map fst dfmtFilePairs

--- a/test/Test/LoggyCore.hs
+++ b/test/Test/LoggyCore.hs
@@ -11,14 +11,14 @@ inputTime = "01:15:00"
 inputTimeWith :: String -> String
 inputTimeWith = (inputTime ++) 
 
-inputDiffTime :: DiffTime 
-inputDiffTime = 4500
+inputDiffTime :: Maybe DiffTime 
+inputDiffTime = Just 4500
 
 dateFormat :: DateFormat 
 dateFormat = "%H:%M:%S"
 
-mergeLogLinesTester :: DateFormat -> [LogFileLines] -> [LogLine]
-mergeLogLinesTester dformat lfiles = mergeLogLines dFormatFilePairs
+testMergeLogs :: DateFormat -> [LogFileLines] -> MergeResult
+testMergeLogs dformat lfiles = mergeLogLines dFormatFilePairs
     where
         dFormatFilePairs = zip dFormatPerFile lfiles
         dFormatPerFile = replicate numFiles dformat
@@ -26,25 +26,42 @@ mergeLogLinesTester dformat lfiles = mergeLogLines dFormatFilePairs
 
 loggycore :: Spec
 loggycore = describe "LoggyCoreTest" $ do
-    describe "LoggyCore: extractTimestamp" $ do
-        it "simpleTimestamp" $ utctDayTime (extractTimestamp dateFormat inputTime) `shouldBe` inputDiffTime
-        it "simpleTimestampWithSpaces" $ utctDayTime (extractTimestamp dateFormat $ inputTimeWith " ") `shouldBe` inputDiffTime
-        it "simpleTimestampWithExtraChars" $ utctDayTime (extractTimestamp dateFormat $ inputTimeWith " random extra chars") `shouldBe` inputDiffTime   
-        it "simpleTimestampWithRepeatedTimestamp" $ utctDayTime (extractTimestamp dateFormat $ inputTimeWith (" " ++ inputTime)) `shouldBe` inputDiffTime
-        -- TODO: How to test erroneous input case?
-    describe "LoggyCore: mergeLogLines" $ do
-        it "bothEmpty" $ mergeLogLinesTester dateFormat [[],[]] `shouldBe` []
-        it "singleEmpty" $ mergeLogLinesTester dateFormat [[inputTimeWith " sample log line"],[]] `shouldBe` [inputTimeWith " sample log line"]
-        it "sameTimeLogs" $ mergeLogLinesTester dateFormat [[inputTimeWith " sample log line 1"],[inputTimeWith " sample log line 2"]] 
-            `shouldBe` [inputTimeWith " sample log line 1", inputTimeWith " sample log line 2"]
-        it "mergeSingleLineLogs" $ mergeLogLinesTester dateFormat [[inputTimeWith " from file 1"],["01:18:00 from file 2"]]
-            `shouldBe` [inputTimeWith " from file 1", "01:18:00 from file 2"]
-        it "mergeMultiLineLogs" $ mergeLogLinesTester dateFormat [[inputTimeWith " from file 1", "01:23:00 from file 1"],
-                ["01:18:00 from file 2", "01:25:55 from file 2"]]
-            `shouldBe` [inputTimeWith " from file 1", "01:18:00 from file 2", "01:23:00 from file 1", "01:25:55 from file 2"]  
-        it "mergeSingleLineLogsDifferentTimeFormats" $ 
-                mergeLogLines [(dateFormat, [inputTimeWith " from file 1", "01:23:00 from file 1"]),
-                                (dateFormat ++ "XYZ", ["01:18:00XYZ from file 2"])]
-            `shouldBe` [inputTimeWith " from file 1", "01:18:00XYZ from file 2", "01:23:00 from file 1"]
+    extractTimestampTest
+    mergeLogLinesTest
 
+extractTimestampTest :: Spec
+extractTimestampTest = describe "LoggyCoreTest: extractTimestamp" $ do
+    it "simpleTimestamp" $ extractTsHelper inputTime `shouldBe` inputDiffTime
+    it "simpleTimestampWithSpaces" $ extractTsHelper (inputTimeWith " ") `shouldBe` inputDiffTime
+    it "simpleTimestampWithExtraChars" $ extractTsHelper (inputTimeWith " random extra chars") `shouldBe` inputDiffTime   
+    it "simpleTimestampWithRepeatedTimestamp" $ extractTsHelper (inputTimeWith $ " " ++ inputTime) `shouldBe` inputDiffTime
+    it "invalidLogLine" $ extractTsHelper "invalid input" `shouldBe` Nothing
+        where
+            extractTsHelper tsLog = utctDayTime <$> extractTimestamp dateFormat tsLog
 
+mergeLogLinesTest :: Spec
+mergeLogLinesTest = describe "LoggyCoreTest: mergeLogLines" $ do
+    it "bothEmpty" $ testMergeLogs dateFormat [[],[]] `shouldBe` MkMergeResult [] NoWarning
+    it "singleEmpty" $ testMergeLogs dateFormat
+                            [[inputTimeWith " sample log line"],[]]
+                `shouldBe` MkMergeResult [inputTimeWith " sample log line"] NoWarning
+    it "sameTimeLogs" $ testMergeLogs dateFormat 
+                            [[inputTimeWith " sample log line 1"],[inputTimeWith " sample log line 2"]] 
+                `shouldBe` MkMergeResult [inputTimeWith " sample log line 1", inputTimeWith " sample log line 2"] NoWarning
+    it "mergeSingleLineLogs" $ testMergeLogs dateFormat 
+                            [[inputTimeWith " from file 1"],["01:18:00 from file 2"]]
+                `shouldBe` MkMergeResult [inputTimeWith " from file 1", "01:18:00 from file 2"] NoWarning
+    it "mergeMultiLineLogs" $ testMergeLogs dateFormat 
+                            [[inputTimeWith " from file 1", "01:23:00 from file 1"],
+                             ["01:18:00 from file 2", "01:25:55 from file 2"]]
+                `shouldBe` MkMergeResult [inputTimeWith " from file 1", "01:18:00 from file 2", 
+                            "01:23:00 from file 1", "01:25:55 from file 2"] NoWarning
+    it "mergeSingleLineLogsDifferentTimeFormats" $ 
+            mergeLogLines [(dateFormat, [inputTimeWith " from file 1", "01:23:00 from file 1"]),
+                            (dateFormat ++ "XYZ", ["01:18:00XYZ from file 2"])]
+        `shouldBe` MkMergeResult [inputTimeWith " from file 1", "01:18:00XYZ from file 2", 
+                                  "01:23:00 from file 1"] NoWarning
+    it "invalidLogLine" $ testMergeLogs dateFormat [[" invalid log line"]]
+                `shouldBe` MkMergeResult [] InvalidLogLine
+    it "invalidLogLines" $ testMergeLogs dateFormat [[" invalid log line", inputTimeWith " from file 1"]]
+                    `shouldBe` MkMergeResult [inputTimeWith " from file 1"] InvalidLogLine


### PR DESCRIPTION
Return a WarnCode that results in a stderr warning + skip any invalid
log lines (not containing a strftime matching datetime format).
Subsequently, we'll attempt to group such "invalid" lines (those missing
a timestamp) with the last line that contained a timestamp.